### PR TITLE
Support Python3.10 and bump up version to 0.2.0

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.8
+    - name: Set up
       uses: actions/setup-python@v3
       with:
-        python-version: "3.8"
+        python-version: ["3.8", "3.9", "3.10"]
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -17,12 +17,16 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10"]
+
     steps:
     - uses: actions/checkout@v3
-    - name: Set up
+    - name: Set up ${{ matrix.python-version }}
       uses: actions/setup-python@v3
       with:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/anaconda/meta.yaml
+++ b/anaconda/meta.yaml
@@ -1,6 +1,6 @@
 package:
     name: snowflake_telemetry_python
-    version: "0.1.0"
+    version: "0.2.0"
 
 source:
     path: /tmp/anaconda_workspace/src

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Topic :: Database",
         "Topic :: Software Development",
         "Topic :: Software Development :: Libraries",

--- a/src/snowflake/telemetry/version.py
+++ b/src/snowflake/telemetry/version.py
@@ -4,4 +4,4 @@
 #
 
 """Update this for the versions."""
-VERSION = (0, 1, 0)
+VERSION = (0, 2, 0)


### PR DESCRIPTION
This PR bumps snowflake-telemetry-python version to 0.2.0 and add support for Python 3.10
