### PR TITLE
SNOW-1011499 Add build.sh for building conda package from Jenkins

### DIFF
--- a/anaconda/bld.bat
+++ b/anaconda/bld.bat
@@ -1,1 +1,1 @@
-$PYTHON setup.py install
+"%PYTHON%" setup.py install

--- a/anaconda/build.sh
+++ b/anaconda/build.sh
@@ -1,1 +1,1 @@
-$PYTHON setup.py install --single-version-externally-managed --record=record.txt
+${PYTHON} setup.py install --single-version-externally-managed --record=record.txt

--- a/anaconda/meta.yaml
+++ b/anaconda/meta.yaml
@@ -3,7 +3,7 @@ package:
     version: "0.2.1.dev"
 
 source:
-    path: /tmp/anaconda_workspace/src
+    path: {{ environ.get('SNOWFLAKE_TELEMETRY_DIR') }}
 
 requirements:
     build:
@@ -18,6 +18,5 @@ requirements:
 about:
     home: https://www.snowflake.com/
     license: Apache 2.0
-    license_file: /tmp/anaconda_workspace/src/LICENSE.txt
-    summary: Snowflake Telemetry Python package 
-
+    license_file: {{ environ.get('SNOWFLAKE_TELEMETRY_DIR') }}/LICENSE.txt
+    summary: Snowflake Telemetry Python package

--- a/build.sh
+++ b/build.sh
@@ -39,7 +39,7 @@ conda config --add channels https://repo.anaconda.com/pkgs/snowflake/
 
 # clean up the dist directory
 rm -rf ./anaconda/dist
-mkdir ./anaconda/dist
+mkdir -p ./anaconda/dist
 
 if [ "$BUILD_CONDA_FORMAT" = true ] ; then
   # NOTE: the below is to output the build in .conda format.

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,57 @@
+#!/bin/bash -xe
+
+# This script builds snowflake-telemetry-python for release. It is called from
+# a Jenkins job called SnowflakeTelemetryAnacondaPackageBuilder.
+#
+# Prequisites:
+# - activate a conda environment
+# - have conda-build installed, e.g. `conda install conda-build`
+# - have conda-verify installed, e.g. `conda install conda-verify`
+#
+# Then, run this script.
+#
+# Note: While this script is intended to be run in the Jenkins environment to
+# create official build artifacts, you can test it on your MacBook by
+# installing miniconda3, then creating an environment like this:
+#
+# conda create -n my-conda-build-environment python=3.8 conda-build git
+# conda activate my-conda-build-environment
+# # cd into the snowflake-telemetry-python git root dir
+# export SNOWFLAKE_TELEMETRY_DIR=$(pwd)
+
+make_conda_build () {
+  # set default build number to 0, if SNOWFLAKE_TELEMETRY_BUILD_NUMBER is not set
+  echo "Start building snowflake-telemetry-python package with build_number: ${SNOWFLAKE_TELEMETRY_BUILD_NUMBER:=0}"
+  # conda build takes GIT_HASH as environment variable and embed it into the build package name
+  GIT_HASH=$(git rev-parse --short HEAD) SNOWFLAKE_TELEMETRY_BUILD_NUMBER=${SNOWFLAKE_TELEMETRY_BUILD_NUMBER:=0} conda build ./anaconda --output-folder ./anaconda/dist
+}
+
+BUILD_CONDA_FORMAT=false
+while getopts ":c" option; do
+  case $option in
+    c) # conda format
+      BUILD_CONDA_FORMAT=true
+  esac
+done
+
+# set up private channel to make opentelemetry dependencies available
+conda config --add channels https://repo.anaconda.com/pkgs/snowflake/
+
+# clean up the dist directory
+rm -rf ./anaconda/dist
+mkdir ./anaconda/dist
+
+if [ "$BUILD_CONDA_FORMAT" = true ] ; then
+  # NOTE: the below is to output the build in .conda format.
+  # To do so, we set conda_build.pkg_format = 2 and then
+  # remove it later to go back to default behavior.
+  conda config --set conda_build.pkg_format 2
+  make_conda_build
+  conda config --remove-key conda_build.pkg_format
+else
+  make_conda_build
+fi
+
+# clean up the conda environment
+conda config --remove channels https://repo.anaconda.com/pkgs/snowflake/
+conda build purge


### PR DESCRIPTION
For CI testing, we need to regularly generate release artifacts so we can do integration testing with them.

This PR adds a new build.sh script, which gets used by this new Jenkins job to generate the release artifacts:
https://ci-dev-142.int.snowflakecomputing.com/job/SnowflakeTelemetryAnacondaPackageBuilder/

build.sh can also be run in the MacOS environment with miniconda3 installed.

Related PR in jenkins_utils:
https://github.com/snowflakedb/jenkins_utils/pull/10762
