### PR TITLE
SNOW-1063077 Update release notes and prep for 0.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
-Release History
+# Release History
+
+## 0.3.0 (2024-03-11)
+
+* The `telemetry.add_event` function now adds an event to the current span, if any. This was a no op stub function before.
+* The `telemetry.add_span_attribute` function now adds an attribute to the current span, if any. This was a no op stub function before.
+* Added support for Python 3.11
+* Removed support for Python 3.7
+* Added `snowflake.telemetry._internal` module that wraps opentelemetry modules for use internally by Snowflake
+
+## 0.2.0 (2023-05-01)
+
+* Added support for Python 3.10
+
+## 0.1.0 (2022-09-29)
+
+* Update README and docstring to indicate this package is a stub
 
 ## 0.0.0 (2022-09-09)
 
-Initial release.
+* Initial release.

--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@
 
 `snowflake-telemetry-python` is a package that supports emitting telemetry data from Python UDFs, UDTFs, and Stored Procedures.
 
-The package is a stub for the full functionality when running in Snowflake.
-
 ## Getting started
 
 To install the latest release of this package as an end user, run

--- a/anaconda/meta.yaml
+++ b/anaconda/meta.yaml
@@ -1,6 +1,6 @@
 package:
     name: snowflake_telemetry_python
-    version: "0.2.1.dev"
+    version: "0.3.0.dev"
 
 source:
     path: {{ environ.get('SNOWFLAKE_TELEMETRY_DIR') }}

--- a/src/snowflake/telemetry/version.py
+++ b/src/snowflake/telemetry/version.py
@@ -4,4 +4,4 @@
 #
 
 """Update this for the versions."""
-VERSION = "0.2.1.dev"
+VERSION = "0.3.0.dev"

--- a/tests/snowflake-telemetry-test-utils/setup.py
+++ b/tests/snowflake-telemetry-test-utils/setup.py
@@ -17,7 +17,7 @@ setup(
     long_description=LONG_DESCRIPTION,
     install_requires=[
         "pytest >= 7.0.0",
-        "snowflake-telemetry-python == 0.2.1.dev",
+        "snowflake-telemetry-python == 0.3.0.dev",
     ],
     packages=find_namespace_packages(
         where='src'


### PR DESCRIPTION
0.3.0 is a bridge release that does not change the dependencies of snowflake-telemetry-python, but introduces the stable API that we need to be able to support multiple versions of snowflake-telemetry-python and opentelemetry-python properly internally.