### PR TITLE
SNOW-1042090 Add release notes to prepare for 0.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release History
 
+## 0.4.0 (2024-04-17)
+
+* Upgrade OpenTelemetry Python dependencies to version 1.23.0
+* Drop the dependency on package opentelemetry-exporter-otlp and all its transitive dependencies
+* Add a dependency on package opentelemetry-exporter-otlp-proto-common, a lighter weight package that brings in fewer transitive dependencies
+* Remove unnecessary upper bound on setuptools dependency
+
 ## 0.3.0 (2024-03-11)
 
 * The `telemetry.add_event` function now adds an event to the current span, if any. This was a no op stub function before.

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -xe
 
 # This script builds snowflake-telemetry-python for release. It is called from
-# a Jenkins job called SnowflakeTelemetryAnacondaPackageBuilder.
+# a Jenkins job called SnowflakeTelemetryPythonPackageBuilder.
 #
 # Prequisites:
 # - activate a conda environment

--- a/pypi-build.sh
+++ b/pypi-build.sh
@@ -1,0 +1,39 @@
+#!/bin/bash -xe
+
+# This script builds snowflake-telemetry-python for release. It is called from
+# a Jenkins job called SnowflakeTelemetryPythonPackageBuilder.
+#
+# Prequisites:
+# - activate a clean virtual environment with
+#     python3 -m venv .venv
+#     source .venv/bin/activate
+#
+# Then, run this script.
+#
+# Note: While this script is intended to be run in the Jenkins environment to
+# create official build artifacts, you can test it on your MacBook by
+# using its built-in python3, then creating an environment like this:
+#
+# python3 -m venv .venv
+# source .venv/bin/activate
+# # cd into the snowflake-telemetry-python git root dir
+# export SNOWFLAKE_TELEMETRY_DIR=$(pwd)
+
+VENV_DIR=venv_$(date +%s)
+python3 -m venv ${VENV_DIR}
+source ${VENV_DIR}/bin/activate
+
+# install and upgrade pre-requisite packages for building snowflake-telemetry-python
+python3 -m pip install --upgrade pip
+python3 -m pip install --upgrade build
+
+# clean up the dist directory
+rm -rf ./dist
+mkdir ./dist
+
+# set default build number to 0, if SNOWFLAKE_TELEMETRY_BUILD_NUMBER is not set
+echo "Start building snowflake-telemetry-python package with build_number: ${SNOWFLAKE_TELEMETRY_BUILD_NUMBER:=0}"
+SNOWFLAKE_TELEMETRY_BUILD_NUMBER=${SNOWFLAKE_TELEMETRY_BUILD_NUMBER:=0} python3 -m build
+
+deactivate
+rm -rf ${VENV_DIR}

--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,10 @@ from setuptools import (
     setup,
 )
 
-DESCRIPTION = 'Snowflake Telemetry Python'
+DESCRIPTION = 'Snowflake Telemetry for Python'
 LONG_DESCRIPTION = """This package provides a set of telemetry APIs for developers building on the Snowflake platform.
 
-Snowflake Documentation is available at: https://docs.snowflake.com/
+Documentation is available at: https://docs.snowflake.com/en/developer-guide/logging-tracing/tracing-python
 
 Source code is also available at: https://github.com/snowflakedb/snowflake-telemetry-python
 """
@@ -27,7 +27,6 @@ setup(
     description=DESCRIPTION,
     long_description=LONG_DESCRIPTION,
     install_requires=[
-        "setuptools >= 40.0.0",
         "opentelemetry-api == 1.23.0",
         "opentelemetry-exporter-otlp-proto-common == 1.23.0",
         "opentelemetry-sdk == 1.23.0",
@@ -64,7 +63,7 @@ setup(
     project_urls={
         "Homepage": "https://www.snowflake.com/",
         "Changelog": "https://github.com/snowflakedb/snowflake-telemetry-python/blob/main/CHANGELOG.md",
-        "Documentation": "https://docs.snowflake.com/en/developer-guide/logging-tracing/logging-tracing-overview",
+        "Documentation": "https://docs.snowflake.com/en/developer-guide/logging-tracing/tracing-python",
         "Issues": "https://github.com/snowflakedb/snowflake-telemetry-python/issues",
         "Repository": "https://github.com/snowflakedb/snowflake-telemetry-python/",
     },

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,12 @@ from setuptools import (
 )
 
 DESCRIPTION = 'Snowflake Telemetry Python'
-LONG_DESCRIPTION = 'This package provides a set of telemetry APIs for use in Snowflake'
+LONG_DESCRIPTION = """This package provides a set of telemetry APIs for developers building on the Snowflake platform.
+
+Snowflake Documentation is available at: https://docs.snowflake.com/
+
+Source code is also available at: https://github.com/snowflakedb/snowflake-telemetry-python
+"""
 SNOWFLAKE_TELEMETRY_SRC_DIR = os.path.join("src", "snowflake", "telemetry")
 
 VERSION = None
@@ -18,6 +23,7 @@ setup(
     version=VERSION,
     author="Snowflake, Inc",
     author_email="support@snowflake.com",
+    url="https://www.snowflake.com/",
     description=DESCRIPTION,
     long_description=LONG_DESCRIPTION,
     install_requires=[
@@ -54,6 +60,13 @@ setup(
         "Topic :: Software Development :: Libraries :: Application Frameworks",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Topic :: Scientific/Engineering :: Information Analysis",
-     ],
+    ],
+    project_urls={
+        "Homepage": "https://www.snowflake.com/",
+        "Changelog": "https://github.com/snowflakedb/snowflake-telemetry-python/blob/main/CHANGELOG.md",
+        "Documentation": "https://docs.snowflake.com/en/developer-guide/logging-tracing/logging-tracing-overview",
+        "Issues": "https://github.com/snowflakedb/snowflake-telemetry-python/issues",
+        "Repository": "https://github.com/snowflakedb/snowflake-telemetry-python/",
+    },
     zip_safe=True,
 )

--- a/tests/snowflake-telemetry-test-utils/setup.py
+++ b/tests/snowflake-telemetry-test-utils/setup.py
@@ -1,4 +1,3 @@
-import os
 from setuptools import (
     find_namespace_packages,
     setup,


### PR DESCRIPTION
- SNOW-1042090 Add release notes to prepare for 0.4.0 release
- SNOW-1042090 add project_urls and better long description

project_urls and the better long description are intended to improve the way our package shows up on PyPI. For example, here is a TestPyPI URL for our project with these changes applied (0.3.1).

https://test.pypi.org/project/snowflake-telemetry-python/
