### PR TITLE
SNOW-1410799 Set empty resource for Python OpenTelemetry config

### DIFF
--- a/src/snowflake/telemetry/_internal/exporter/otlp/proto/logs/__init__.py
+++ b/src/snowflake/telemetry/_internal/exporter/otlp/proto/logs/__init__.py
@@ -25,7 +25,7 @@ from opentelemetry.exporter.otlp.proto.common._log_encoder import (
     encode_logs,
 )
 from opentelemetry.proto.logs.v1.logs_pb2 import LogsData
-from opentelemetry.sdk import resources
+from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk._logs import export
 from opentelemetry.sdk import _logs
 from opentelemetry.util import types
@@ -138,7 +138,7 @@ class _SnowflakeTelemetryLogger(_logs.Logger):
 
     def __init__(
         self,
-        resource: resources.Resource,
+        resource: Resource,
         multi_log_record_processor: typing.Union[
             _logs_internal.SynchronousMultiLogRecordProcessor,
             _logs_internal.ConcurrentMultiLogRecordProcessor,
@@ -189,7 +189,7 @@ class _SnowflakeTelemetryLoggerProvider(_logs.LoggerProvider):
         schema_url: types.Optional[str] = None,
     ) -> _logs.Logger:
         return _SnowflakeTelemetryLogger(
-            self._resource,
+            Resource.get_empty(),
             self._multi_log_record_processor,
             otel_instrumentation.InstrumentationScope(
                 name,

--- a/tests/test_proto_logs_exporter.py
+++ b/tests/test_proto_logs_exporter.py
@@ -43,6 +43,7 @@ class TestSnowflakeLoggingHandler(unittest.TestCase):
         self.root_logger.warn("warn, something is wrong")
         finished_protos = self.log_writer.get_finished_protos()
         self.assertEqual(len(finished_protos), 2)
+        self.assertEqual(len(finished_protos[0].resource_logs[0].resource.attributes), 0)
         self.assertEqual(finished_protos[0].resource_logs[0].scope_logs[0].scope.name, "root")
         warning_log_record = finished_protos[0].resource_logs[0].scope_logs[0].log_records[0]
         self._log_record_check_helper(
@@ -52,6 +53,7 @@ class TestSnowflakeLoggingHandler(unittest.TestCase):
             SEVERITY_NUMBER_WARN,
             this_method_name
         )
+        self.assertEqual(len(finished_protos[1].resource_logs[0].resource.attributes), 0)
         self.assertEqual(finished_protos[1].resource_logs[0].scope_logs[0].scope.name, "root")
         warn_log_record = finished_protos[1].resource_logs[0].scope_logs[0].log_records[0]
         self._log_record_check_helper(
@@ -68,6 +70,7 @@ class TestSnowflakeLoggingHandler(unittest.TestCase):
         self.root_logger.error("error, something is wrong")
         finished_protos = self.log_writer.get_finished_protos()
         self.assertEqual(len(finished_protos), 1)
+        self.assertEqual(len(finished_protos[0].resource_logs[0].resource.attributes), 0)
         self.assertEqual(finished_protos[0].resource_logs[0].scope_logs[0].scope.name, "root")
         error_log_record = finished_protos[0].resource_logs[0].scope_logs[0].log_records[0]
         self._log_record_check_helper(
@@ -84,6 +87,7 @@ class TestSnowflakeLoggingHandler(unittest.TestCase):
         self.root_logger.critical("critical, something is wrong")
         finished_protos = self.log_writer.get_finished_protos()
         self.assertEqual(len(finished_protos), 1)
+        self.assertEqual(len(finished_protos[0].resource_logs[0].resource.attributes), 0)
         self.assertEqual(finished_protos[0].resource_logs[0].scope_logs[0].scope.name, "root")
         fatal_log_record = finished_protos[0].resource_logs[0].scope_logs[0].log_records[0]
         self._log_record_check_helper(
@@ -102,6 +106,7 @@ class TestSnowflakeLoggingHandler(unittest.TestCase):
         local_logger.critical("critical, something is wrong at local scope")
         finished_protos = self.log_writer.get_finished_protos()
         self.assertEqual(len(finished_protos), 2)
+        self.assertEqual(len(finished_protos[0].resource_logs[0].resource.attributes), 0)
         self.assertEqual(finished_protos[0].resource_logs[0].scope_logs[0].scope.name, "root")
         root_log_record = finished_protos[0].resource_logs[0].scope_logs[0].log_records[0]
         self._log_record_check_helper(
@@ -112,6 +117,7 @@ class TestSnowflakeLoggingHandler(unittest.TestCase):
             this_method_name
         )
         local_log_record = finished_protos[1].resource_logs[0].scope_logs[0].log_records[0]
+        self.assertEqual(len(finished_protos[1].resource_logs[0].resource.attributes), 0)
         self.assertEqual(finished_protos[1].resource_logs[0].scope_logs[0].scope.name, "tests")
         self._log_record_check_helper(
             local_log_record,


### PR DESCRIPTION
Set empty resource for Python because we are not using the resource attributes from OTEL proto to populate event table resource_attribute column.

This change will make merging resource attributes from external protos easier. https://github.com/snowflakedb/snowflake/pull/166157