### PR TITLE
Remove opentelemetry-exporter-otlp-proto-common dependency

### DIFF
--- a/benchmark/benchmark_serialize.py
+++ b/benchmark/benchmark_serialize.py
@@ -1,0 +1,86 @@
+import google_benchmark as benchmark
+
+from util import get_logs_data, get_metrics_data, get_traces_data, get_logs_data_4MB
+
+from snowflake.telemetry._internal.opentelemetry.exporter.otlp.proto.common._log_encoder import encode_logs
+from snowflake.telemetry._internal.opentelemetry.exporter.otlp.proto.common.metrics_encoder import encode_metrics
+from snowflake.telemetry._internal.opentelemetry.exporter.otlp.proto.common.trace_encoder import encode_spans
+
+from opentelemetry.exporter.otlp.proto.common._log_encoder import encode_logs as pb2_encode_logs
+from opentelemetry.exporter.otlp.proto.common.metrics_encoder import encode_metrics as pb2_encode_metrics
+from opentelemetry.exporter.otlp.proto.common.trace_encoder import encode_spans as pb2_encode_spans
+
+"""
+------------------------------------------------------------------------------
+Benchmark                                    Time             CPU   Iterations
+------------------------------------------------------------------------------
+test_bm_serialize_logs_data_4MB      218404625 ns    218404667 ns            3
+test_bm_pb2_serialize_logs_data_4MB  279917764 ns    279916000 ns            3
+test_bm_serialize_logs_data              35747 ns        35747 ns        19741
+test_bm_pb2_serialize_logs_data          41652 ns        41651 ns        16939
+test_bm_serialize_metrics_data           59798 ns        59798 ns        11593
+test_bm_pb2_serialize_metrics_data       70521 ns        70521 ns         9815
+test_bm_serialize_traces_data            47156 ns        47156 ns        14807
+test_bm_pb2_serialize_traces_data        59690 ns        59690 ns        11766
+"""
+
+def sanity_check():
+    logs_data = get_logs_data()
+    metrics_data = get_metrics_data()
+    traces_data = get_traces_data()
+
+    assert encode_logs(logs_data) == pb2_encode_logs(logs_data).SerializeToString()
+    assert encode_metrics(metrics_data) == pb2_encode_metrics(metrics_data).SerializeToString()
+    assert encode_spans(traces_data) == pb2_encode_spans(traces_data).SerializeToString()
+
+@benchmark.register
+def test_bm_serialize_logs_data_4MB(state):
+    logs_data = get_logs_data_4MB()
+    while state:
+        encode_logs(logs_data)
+
+@benchmark.register
+def test_bm_pb2_serialize_logs_data_4MB(state):
+    logs_data = get_logs_data_4MB()
+    while state:
+        pb2_encode_logs(logs_data).SerializeToString()
+
+@benchmark.register
+def test_bm_serialize_logs_data(state):
+    logs_data = get_logs_data()
+    while state:
+        encode_logs(logs_data)
+
+@benchmark.register
+def test_bm_pb2_serialize_logs_data(state):
+    logs_data = get_logs_data()
+    while state:
+        pb2_encode_logs(logs_data).SerializeToString()
+
+@benchmark.register
+def test_bm_serialize_metrics_data(state):
+    metrics_data = get_metrics_data()
+    while state:
+        encode_metrics(metrics_data)
+
+@benchmark.register
+def test_bm_pb2_serialize_metrics_data(state):
+    metrics_data = get_metrics_data()
+    while state:
+        pb2_encode_metrics(metrics_data).SerializeToString()
+
+@benchmark.register
+def test_bm_serialize_traces_data(state):
+    traces_data = get_traces_data()
+    while state:
+        encode_spans(traces_data)
+
+@benchmark.register
+def test_bm_pb2_serialize_traces_data(state):
+    traces_data = get_traces_data()
+    while state:
+        pb2_encode_spans(traces_data).SerializeToString()
+
+if __name__ == "__main__":
+    sanity_check()
+    benchmark.main()

--- a/benchmark/util.py
+++ b/benchmark/util.py
@@ -1,0 +1,339 @@
+from typing import Sequence
+
+from snowflake.telemetry.test.metrictestutil import _generate_gauge, _generate_sum
+
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.util.instrumentation import InstrumentationScope
+
+from opentelemetry._logs import SeverityNumber
+from opentelemetry.sdk._logs import LogData, LogLimits, LogRecord
+
+from opentelemetry.sdk.metrics.export import (
+    AggregationTemporality, 
+    Buckets,
+    ExponentialHistogram,
+    Histogram,
+    ExponentialHistogramDataPoint,
+    HistogramDataPoint,
+    Metric,
+    MetricsData,
+    ResourceMetrics,
+    ScopeMetrics,
+)
+
+from opentelemetry.sdk.trace import Event, SpanContext, _Span
+from opentelemetry.trace import SpanKind, Link, TraceFlags
+from opentelemetry.trace.status import Status, StatusCode
+
+
+
+def get_logs_data() -> Sequence[LogData]:
+    log1 = LogData(
+        log_record=LogRecord(
+            timestamp=1644650195189786880,
+            observed_timestamp=1644660000000000000,
+            trace_id=89564621134313219400156819398935297684,
+            span_id=1312458408527513268,
+            trace_flags=TraceFlags(0x01),
+            severity_text="WARN",
+            severity_number=SeverityNumber.WARN,
+            body="Do not go gentle into that good night. Rage, rage against the dying of the light",
+            resource=Resource(
+                {"first_resource": "value"},
+                "resource_schema_url",
+            ),
+            attributes={"a": 1, "b": "c"},
+        ),
+        instrumentation_scope=InstrumentationScope(
+            "first_name", "first_version"
+        ),
+    )
+
+    log2 = LogData(
+        log_record=LogRecord(
+            timestamp=1644650249738562048,
+            observed_timestamp=1644660000000000000,
+            trace_id=0,
+            span_id=0,
+            trace_flags=TraceFlags.DEFAULT,
+            severity_text="WARN",
+            severity_number=SeverityNumber.WARN,
+            body="Cooper, this is no time for caution!",
+            resource=Resource({"second_resource": "CASE"}),
+            attributes={},
+        ),
+        instrumentation_scope=InstrumentationScope(
+            "second_name", "second_version"
+        ),
+    )
+
+    log3 = LogData(
+        log_record=LogRecord(
+            timestamp=1644650427658989056,
+            observed_timestamp=1644660000000000000,
+            trace_id=271615924622795969659406376515024083555,
+            span_id=4242561578944770265,
+            trace_flags=TraceFlags(0x01),
+            severity_text="DEBUG",
+            severity_number=SeverityNumber.DEBUG,
+            body="To our galaxy",
+            resource=Resource({"second_resource": "CASE"}),
+            attributes={"a": 1, "b": "c"},
+        ),
+        instrumentation_scope=None,
+    )
+
+    log4 = LogData(
+        log_record=LogRecord(
+            timestamp=1644650584292683008,
+            observed_timestamp=1644660000000000000,
+            trace_id=212592107417388365804938480559624925555,
+            span_id=6077757853989569223,
+            trace_flags=TraceFlags(0x01),
+            severity_text="INFO",
+            severity_number=SeverityNumber.INFO,
+            body="Love is the one thing that transcends time and space",
+            resource=Resource(
+                {"first_resource": "value"},
+                "resource_schema_url",
+            ),
+            attributes={"filename": "model.py", "func_name": "run_method"},
+        ),
+        instrumentation_scope=InstrumentationScope(
+            "another_name", "another_version"
+        ),
+    )
+
+    return [log1, log2, log3, log4]
+
+def get_logs_data_4MB() -> Sequence[LogData]:
+    out = []
+    for _ in range(8000):
+        out.extend(get_logs_data())
+    return out
+
+HISTOGRAM = Metric(
+    name="histogram",
+    description="foo",
+    unit="s",
+    data=Histogram(
+        data_points=[
+            HistogramDataPoint(
+                attributes={"a": 1, "b": True},
+                start_time_unix_nano=1641946016139533244,
+                time_unix_nano=1641946016139533244,
+                count=5,
+                sum=67,
+                bucket_counts=[1, 4],
+                explicit_bounds=[10.0, 20.0],
+                min=8,
+                max=18,
+            )
+        ],
+        aggregation_temporality=AggregationTemporality.DELTA,
+    ),
+)
+
+EXPONENTIAL_HISTOGRAM = Metric(
+    name="exponential_histogram",
+    description="description",
+    unit="unit",
+    data=ExponentialHistogram(
+        data_points=[
+            ExponentialHistogramDataPoint(
+                attributes={"a": 1, "b": True},
+                start_time_unix_nano=0,
+                time_unix_nano=1,
+                count=2,
+                sum=3,
+                scale=4,
+                zero_count=5,
+                positive=Buckets(offset=6, bucket_counts=[7, 8]),
+                negative=Buckets(offset=9, bucket_counts=[10, 11]),
+                flags=12,
+                min=13.0,
+                max=14.0,
+            )
+        ],
+        aggregation_temporality=AggregationTemporality.DELTA,
+    ),
+)
+def get_metrics_data() -> MetricsData:
+
+    metrics = MetricsData(
+        resource_metrics=[
+            ResourceMetrics(
+                resource=Resource(
+                    attributes={"a": 1, "b": False},
+                    schema_url="resource_schema_url",
+                ),
+                scope_metrics=[
+                    ScopeMetrics(
+                        scope=InstrumentationScope(
+                            name="first_name",
+                            version="first_version",
+                            schema_url="insrumentation_scope_schema_url",
+                        ),
+                        metrics=[HISTOGRAM, HISTOGRAM],
+                        schema_url="instrumentation_scope_schema_url",
+                    ),
+                    ScopeMetrics(
+                        scope=InstrumentationScope(
+                            name="second_name",
+                            version="second_version",
+                            schema_url="insrumentation_scope_schema_url",
+                        ),
+                        metrics=[HISTOGRAM],
+                        schema_url="instrumentation_scope_schema_url",
+                    ),
+                    ScopeMetrics(
+                        scope=InstrumentationScope(
+                            name="third_name",
+                            version="third_version",
+                            schema_url="insrumentation_scope_schema_url",
+                        ),
+                        metrics=[HISTOGRAM],
+                        schema_url="instrumentation_scope_schema_url",
+                    ),
+                    ScopeMetrics(
+                        scope=InstrumentationScope(
+                            name="first_name",
+                            version="first_version",
+                            schema_url="insrumentation_scope_schema_url",
+                        ),
+                        metrics=[_generate_sum("sum_int", 33)],
+                        schema_url="instrumentation_scope_schema_url",
+                    ),
+                    ScopeMetrics(
+                        scope=InstrumentationScope(
+                            name="first_name",
+                            version="first_version",
+                            schema_url="insrumentation_scope_schema_url",
+                        ),
+                        metrics=[_generate_sum("sum_double", 2.98)],
+                        schema_url="instrumentation_scope_schema_url",
+                    ),
+                    ScopeMetrics(
+                        scope=InstrumentationScope(
+                            name="first_name",
+                            version="first_version",
+                            schema_url="insrumentation_scope_schema_url",
+                        ),
+                        metrics=[_generate_gauge("gauge_int", 9000)],
+                        schema_url="instrumentation_scope_schema_url",
+                    ),
+                    ScopeMetrics(
+                        scope=InstrumentationScope(
+                            name="first_name",
+                            version="first_version",
+                            schema_url="insrumentation_scope_schema_url",
+                        ),
+                        metrics=[_generate_gauge("gauge_double", 52.028)],
+                        schema_url="instrumentation_scope_schema_url",
+                    ),
+                    ScopeMetrics(
+                        scope=InstrumentationScope(
+                            name="first_name",
+                            version="first_version",
+                            schema_url="insrumentation_scope_schema_url",
+                        ),
+                        metrics=[EXPONENTIAL_HISTOGRAM],
+                        schema_url="instrumentation_scope_schema_url",
+                    )
+                ],
+                schema_url="resource_schema_url",
+            )
+        ]
+    )
+
+    return metrics
+
+def get_traces_data() -> Sequence[_Span]:
+    trace_id = 0x3E0C63257DE34C926F9EFCD03927272E
+
+    base_time = 683647322 * 10**9  # in ns
+    start_times = (
+        base_time,
+        base_time + 150 * 10**6,
+        base_time + 300 * 10**6,
+        base_time + 400 * 10**6,
+    )
+    end_times = (
+        start_times[0] + (50 * 10**6),
+        start_times[1] + (100 * 10**6),
+        start_times[2] + (200 * 10**6),
+        start_times[3] + (300 * 10**6),
+    )
+
+    parent_span_context = SpanContext(
+        trace_id, 0x1111111111111111, is_remote=True
+    )
+
+    other_context = SpanContext(
+        trace_id, 0x2222222222222222, is_remote=False
+    )
+
+    span1 = _Span(
+        name="test-span-1",
+        context=SpanContext(
+            trace_id,
+            0x34BF92DEEFC58C92,
+            is_remote=False,
+            trace_flags=TraceFlags(TraceFlags.SAMPLED),
+        ),
+        parent=parent_span_context,
+        events=(
+            Event(
+                name="event0",
+                timestamp=base_time + 50 * 10**6,
+                attributes={
+                    "annotation_bool": True,
+                    "annotation_string": "annotation_test",
+                    "key_float": 0.3,
+                },
+            ),
+        ),
+        links=(
+            Link(context=other_context, attributes={"key_bool": True}),
+        ),
+        resource=Resource({}, "resource_schema_url"),
+    )
+    span1.start(start_time=start_times[0])
+    span1.set_attribute("key_bool", False)
+    span1.set_attribute("key_string", "hello_world")
+    span1.set_attribute("key_float", 111.22)
+    span1.set_status(Status(StatusCode.ERROR, "Example description"))
+    span1.end(end_time=end_times[0])
+
+    span2 = _Span(
+        name="test-span-2",
+        context=parent_span_context,
+        parent=None,
+        resource=Resource(attributes={"key_resource": "some_resource"}),
+    )
+    span2.start(start_time=start_times[1])
+    span2.end(end_time=end_times[1])
+
+    span3 = _Span(
+        name="test-span-3",
+        context=other_context,
+        parent=None,
+        resource=Resource(attributes={"key_resource": "some_resource"}),
+    )
+    span3.start(start_time=start_times[2])
+    span3.set_attribute("key_string", "hello_world")
+    span3.end(end_time=end_times[2])
+
+    span4 = _Span(
+        name="test-span-4",
+        context=other_context,
+        parent=None,
+        resource=Resource({}, "resource_schema_url"),
+        instrumentation_scope=InstrumentationScope(
+            name="name", version="version"
+        ),
+    )
+    span4.start(start_time=start_times[3])
+    span4.end(end_time=end_times[3])
+
+    return [span1, span2, span3, span4]

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ setup(
     long_description=LONG_DESCRIPTION,
     install_requires=[
         "opentelemetry-api == 1.26.0",
-        "opentelemetry-exporter-otlp-proto-common == 1.26.0",
         "opentelemetry-sdk == 1.26.0",
     ],
     packages=find_namespace_packages(

--- a/src/snowflake/telemetry/_internal/exporter/otlp/proto/logs/__init__.py
+++ b/src/snowflake/telemetry/_internal/exporter/otlp/proto/logs/__init__.py
@@ -21,10 +21,9 @@ import typing
 import opentelemetry.sdk.util.instrumentation as otel_instrumentation
 import opentelemetry.sdk._logs._internal as _logs_internal
 
-from opentelemetry.exporter.otlp.proto.common._log_encoder import (
+from snowflake.telemetry._internal.opentelemetry.exporter.otlp.proto.common._log_encoder import (
     encode_logs,
 )
-from opentelemetry.proto.logs.v1.logs_pb2 import LogsData
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk._logs import export
 from opentelemetry.sdk import _logs
@@ -67,11 +66,7 @@ class _ProtoLogExporter(export.LogExporter):
 
     @staticmethod
     def _serialize_logs_data(batch: typing.Sequence[_logs.LogData]) -> bytes:
-        # pylint gets confused by protobuf-generated code, that's why we must
-        # disable the no-member check below.
-        return LogsData(
-            resource_logs=encode_logs(batch).resource_logs # pylint: disable=no-member
-        ).SerializeToString()
+        return encode_logs(batch)
 
     def shutdown(self):
         pass

--- a/src/snowflake/telemetry/_internal/exporter/otlp/proto/metrics/__init__.py
+++ b/src/snowflake/telemetry/_internal/exporter/otlp/proto/metrics/__init__.py
@@ -17,10 +17,9 @@ import abc
 from typing import Dict
 
 import opentelemetry
-from opentelemetry.exporter.otlp.proto.common.metrics_encoder import (
+from snowflake.telemetry._internal.opentelemetry.exporter.otlp.proto.common.metrics_encoder import (
     encode_metrics,
 )
-from opentelemetry.proto.metrics.v1.metrics_pb2 import MetricsData as PB2MetricsData
 from opentelemetry.sdk.metrics.export import (
     AggregationTemporality,
     MetricExportResult,
@@ -80,11 +79,7 @@ class ProtoMetricExporter(MetricExporter):
 
     @staticmethod
     def _serialize_metrics_data(data: MetricsData) -> bytes:
-        # pylint gets confused by protobuf-generated code, that's why we must
-        # disable the no-member check below.
-        return PB2MetricsData(
-            resource_metrics=encode_metrics(data).resource_metrics # pylint: disable=no-member
-        ).SerializeToString()
+        return encode_metrics(data)
 
     def force_flush(self, timeout_millis: float = 10_000) -> bool:
         return True

--- a/src/snowflake/telemetry/_internal/exporter/otlp/proto/traces/__init__.py
+++ b/src/snowflake/telemetry/_internal/exporter/otlp/proto/traces/__init__.py
@@ -16,10 +16,9 @@ Please see the class documentation for those classes to learn more.
 import abc
 import typing
 
-from opentelemetry.exporter.otlp.proto.common.trace_encoder import (
+from snowflake.telemetry._internal.opentelemetry.exporter.otlp.proto.common.trace_encoder import (
     encode_spans,
 )
-from opentelemetry.proto.trace.v1.trace_pb2 import TracesData
 from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.sdk.trace.export import (
     SpanExportResult,
@@ -70,11 +69,7 @@ class ProtoSpanExporter(SpanExporter):
     def _serialize_traces_data(
         sdk_spans: typing.Sequence[ReadableSpan],
     ) -> bytes:
-        # pylint gets confused by protobuf-generated code, that's why we must
-        # disable the no-member check below.
-        return TracesData(
-            resource_spans=encode_spans(sdk_spans).resource_spans # pylint: disable=no-member
-        ).SerializeToString()
+        return encode_spans(sdk_spans)
 
     def shutdown(self) -> None:
         pass

--- a/src/snowflake/telemetry/_internal/opentelemetry/exporter/otlp/proto/common/__init__.py
+++ b/src/snowflake/telemetry/_internal/opentelemetry/exporter/otlp/proto/common/__init__.py
@@ -13,6 +13,6 @@
 # limitations under the License.
 
 
-from opentelemetry.exporter.otlp.proto.common.version import __version__
+from snowflake.telemetry._internal.opentelemetry.exporter.otlp.proto.common.version import __version__
 
 __all__ = ["__version__"]

--- a/src/snowflake/telemetry/_internal/opentelemetry/exporter/otlp/proto/common/__init__.py
+++ b/src/snowflake/telemetry/_internal/opentelemetry/exporter/otlp/proto/common/__init__.py
@@ -1,0 +1,18 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from opentelemetry.exporter.otlp.proto.common.version import __version__
+
+__all__ = ["__version__"]

--- a/src/snowflake/telemetry/_internal/opentelemetry/exporter/otlp/proto/common/_internal/__init__.py
+++ b/src/snowflake/telemetry/_internal/opentelemetry/exporter/otlp/proto/common/_internal/__init__.py
@@ -1,0 +1,172 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import logging
+from collections.abc import Sequence
+from itertools import count
+from typing import (
+    Any,
+    Mapping,
+    Optional,
+    List,
+    Callable,
+    TypeVar,
+    Dict,
+    Iterator,
+)
+
+from opentelemetry.sdk.util.instrumentation import InstrumentationScope
+from opentelemetry.proto.common.v1.common_pb2 import (
+    InstrumentationScope as PB2InstrumentationScope,
+)
+from opentelemetry.proto.resource.v1.resource_pb2 import (
+    Resource as PB2Resource,
+)
+from opentelemetry.proto.common.v1.common_pb2 import AnyValue as PB2AnyValue
+from opentelemetry.proto.common.v1.common_pb2 import KeyValue as PB2KeyValue
+from opentelemetry.proto.common.v1.common_pb2 import (
+    KeyValueList as PB2KeyValueList,
+)
+from opentelemetry.proto.common.v1.common_pb2 import (
+    ArrayValue as PB2ArrayValue,
+)
+from opentelemetry.sdk.trace import Resource
+from opentelemetry.util.types import Attributes
+
+_logger = logging.getLogger(__name__)
+
+_TypingResourceT = TypeVar("_TypingResourceT")
+_ResourceDataT = TypeVar("_ResourceDataT")
+
+
+def _encode_instrumentation_scope(
+    instrumentation_scope: InstrumentationScope,
+) -> PB2InstrumentationScope:
+    if instrumentation_scope is None:
+        return PB2InstrumentationScope()
+    return PB2InstrumentationScope(
+        name=instrumentation_scope.name,
+        version=instrumentation_scope.version,
+    )
+
+
+def _encode_resource(resource: Resource) -> PB2Resource:
+    return PB2Resource(attributes=_encode_attributes(resource.attributes))
+
+
+def _encode_value(value: Any) -> PB2AnyValue:
+    if isinstance(value, bool):
+        return PB2AnyValue(bool_value=value)
+    if isinstance(value, str):
+        return PB2AnyValue(string_value=value)
+    if isinstance(value, int):
+        return PB2AnyValue(int_value=value)
+    if isinstance(value, float):
+        return PB2AnyValue(double_value=value)
+    if isinstance(value, Sequence):
+        return PB2AnyValue(
+            array_value=PB2ArrayValue(values=[_encode_value(v) for v in value])
+        )
+    elif isinstance(value, Mapping):
+        return PB2AnyValue(
+            kvlist_value=PB2KeyValueList(
+                values=[_encode_key_value(str(k), v) for k, v in value.items()]
+            )
+        )
+    raise Exception(f"Invalid type {type(value)} of value {value}")
+
+
+def _encode_key_value(key: str, value: Any) -> PB2KeyValue:
+    return PB2KeyValue(key=key, value=_encode_value(value))
+
+
+def _encode_span_id(span_id: int) -> bytes:
+    return span_id.to_bytes(length=8, byteorder="big", signed=False)
+
+
+def _encode_trace_id(trace_id: int) -> bytes:
+    return trace_id.to_bytes(length=16, byteorder="big", signed=False)
+
+
+def _encode_attributes(
+    attributes: Attributes,
+) -> Optional[List[PB2KeyValue]]:
+    if attributes:
+        pb2_attributes = []
+        for key, value in attributes.items():
+            # pylint: disable=broad-exception-caught
+            try:
+                pb2_attributes.append(_encode_key_value(key, value))
+            except Exception as error:
+                _logger.exception("Failed to encode key %s: %s", key, error)
+    else:
+        pb2_attributes = None
+    return pb2_attributes
+
+
+def _get_resource_data(
+    sdk_resource_scope_data: Dict[Resource, _ResourceDataT],
+    resource_class: Callable[..., _TypingResourceT],
+    name: str,
+) -> List[_TypingResourceT]:
+    resource_data = []
+
+    for (
+        sdk_resource,
+        scope_data,
+    ) in sdk_resource_scope_data.items():
+        collector_resource = PB2Resource(
+            attributes=_encode_attributes(sdk_resource.attributes)
+        )
+        resource_data.append(
+            resource_class(
+                **{
+                    "resource": collector_resource,
+                    "scope_{}".format(name): scope_data.values(),
+                }
+            )
+        )
+    return resource_data
+
+
+def _create_exp_backoff_generator(max_value: int = 0) -> Iterator[int]:
+    """
+    Generates an infinite sequence of exponential backoff values. The sequence starts
+    from 1 (2^0) and doubles each time (2^1, 2^2, 2^3, ...). If a max_value is specified
+    and non-zero, the generated values will not exceed this maximum, capping at max_value
+    instead of growing indefinitely.
+    Parameters:
+    - max_value (int, optional): The maximum value to yield. If 0 or not provided, the
+      sequence grows without bound.
+    Returns:
+    Iterator[int]: An iterator that yields the exponential backoff values, either uncapped or
+    capped at max_value.
+    Example:
+    ```
+    gen = _create_exp_backoff_generator(max_value=10)
+    for _ in range(5):
+        print(next(gen))
+    ```
+    This will print:
+    1
+    2
+    4
+    8
+    10
+    Note: this functionality used to be handled by the 'backoff' package.
+    """
+    for i in count(0):
+        out = 2**i
+        yield min(out, max_value) if max_value else out

--- a/src/snowflake/telemetry/_internal/opentelemetry/exporter/otlp/proto/common/_internal/_log_encoder/__init__.py
+++ b/src/snowflake/telemetry/_internal/opentelemetry/exporter/otlp/proto/common/_internal/_log_encoder/__init__.py
@@ -1,0 +1,95 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from collections import defaultdict
+from typing import Sequence, List
+
+from opentelemetry.exporter.otlp.proto.common._internal import (
+    _encode_instrumentation_scope,
+    _encode_resource,
+    _encode_span_id,
+    _encode_trace_id,
+    _encode_value,
+    _encode_attributes,
+)
+from opentelemetry.proto.collector.logs.v1.logs_service_pb2 import (
+    ExportLogsServiceRequest,
+)
+from opentelemetry.proto.logs.v1.logs_pb2 import (
+    ScopeLogs,
+    ResourceLogs,
+)
+from opentelemetry.proto.logs.v1.logs_pb2 import LogRecord as PB2LogRecord
+
+from opentelemetry.sdk._logs import LogData
+
+
+def encode_logs(batch: Sequence[LogData]) -> ExportLogsServiceRequest:
+    return ExportLogsServiceRequest(resource_logs=_encode_resource_logs(batch))
+
+
+def _encode_log(log_data: LogData) -> PB2LogRecord:
+    span_id = (
+        None
+        if log_data.log_record.span_id == 0
+        else _encode_span_id(log_data.log_record.span_id)
+    )
+    trace_id = (
+        None
+        if log_data.log_record.trace_id == 0
+        else _encode_trace_id(log_data.log_record.trace_id)
+    )
+    return PB2LogRecord(
+        time_unix_nano=log_data.log_record.timestamp,
+        observed_time_unix_nano=log_data.log_record.observed_timestamp,
+        span_id=span_id,
+        trace_id=trace_id,
+        flags=int(log_data.log_record.trace_flags),
+        body=_encode_value(log_data.log_record.body),
+        severity_text=log_data.log_record.severity_text,
+        attributes=_encode_attributes(log_data.log_record.attributes),
+        dropped_attributes_count=log_data.log_record.dropped_attributes,
+        severity_number=log_data.log_record.severity_number.value,
+    )
+
+
+def _encode_resource_logs(batch: Sequence[LogData]) -> List[ResourceLogs]:
+    sdk_resource_logs = defaultdict(lambda: defaultdict(list))
+
+    for sdk_log in batch:
+        sdk_resource = sdk_log.log_record.resource
+        sdk_instrumentation = sdk_log.instrumentation_scope or None
+        pb2_log = _encode_log(sdk_log)
+
+        sdk_resource_logs[sdk_resource][sdk_instrumentation].append(pb2_log)
+
+    pb2_resource_logs = []
+
+    for sdk_resource, sdk_instrumentations in sdk_resource_logs.items():
+        scope_logs = []
+        for sdk_instrumentation, pb2_logs in sdk_instrumentations.items():
+            scope_logs.append(
+                ScopeLogs(
+                    scope=(_encode_instrumentation_scope(sdk_instrumentation)),
+                    log_records=pb2_logs,
+                )
+            )
+        pb2_resource_logs.append(
+            ResourceLogs(
+                resource=_encode_resource(sdk_resource),
+                scope_logs=scope_logs,
+                schema_url=sdk_resource.schema_url,
+            )
+        )
+
+    return pb2_resource_logs

--- a/src/snowflake/telemetry/_internal/opentelemetry/exporter/otlp/proto/common/_internal/_log_encoder/__init__.py
+++ b/src/snowflake/telemetry/_internal/opentelemetry/exporter/otlp/proto/common/_internal/_log_encoder/__init__.py
@@ -14,7 +14,7 @@
 from collections import defaultdict
 from typing import Sequence, List
 
-from opentelemetry.exporter.otlp.proto.common._internal import (
+from snowflake.telemetry._internal.opentelemetry.exporter.otlp.proto.common._internal import (
     _encode_instrumentation_scope,
     _encode_resource,
     _encode_span_id,
@@ -22,21 +22,19 @@ from opentelemetry.exporter.otlp.proto.common._internal import (
     _encode_value,
     _encode_attributes,
 )
-from opentelemetry.proto.collector.logs.v1.logs_service_pb2 import (
-    ExportLogsServiceRequest,
-)
-from opentelemetry.proto.logs.v1.logs_pb2 import (
+from snowflake.telemetry._internal.opentelemetry.proto.logs.v1.logs import (
     ScopeLogs,
     ResourceLogs,
+    LogsData,
 )
-from opentelemetry.proto.logs.v1.logs_pb2 import LogRecord as PB2LogRecord
+from snowflake.telemetry._internal.opentelemetry.proto.logs.v1.logs import LogRecord as PB2LogRecord
 
 from opentelemetry.sdk._logs import LogData
 
 
-def encode_logs(batch: Sequence[LogData]) -> ExportLogsServiceRequest:
-    return ExportLogsServiceRequest(resource_logs=_encode_resource_logs(batch))
-
+def encode_logs(batch: Sequence[LogData]) -> bytes:
+    return bytes(LogsData(resource_logs=_encode_resource_logs(batch))
+)
 
 def _encode_log(log_data: LogData) -> PB2LogRecord:
     span_id = (

--- a/src/snowflake/telemetry/_internal/opentelemetry/exporter/otlp/proto/common/_internal/metrics_encoder/__init__.py
+++ b/src/snowflake/telemetry/_internal/opentelemetry/exporter/otlp/proto/common/_internal/metrics_encoder/__init__.py
@@ -1,0 +1,338 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+
+from opentelemetry.sdk.metrics.export import (
+    MetricExporter,
+)
+from opentelemetry.sdk.metrics.view import Aggregation
+from os import environ
+from opentelemetry.sdk.metrics import (
+    Counter,
+    Histogram,
+    ObservableCounter,
+    ObservableGauge,
+    ObservableUpDownCounter,
+    UpDownCounter,
+)
+from opentelemetry.exporter.otlp.proto.common._internal import (
+    _encode_attributes,
+)
+from opentelemetry.sdk.environment_variables import (
+    OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE,
+)
+from opentelemetry.sdk.metrics.export import (
+    AggregationTemporality,
+)
+from opentelemetry.proto.collector.metrics.v1.metrics_service_pb2 import (
+    ExportMetricsServiceRequest,
+)
+from opentelemetry.proto.common.v1.common_pb2 import InstrumentationScope
+from opentelemetry.proto.metrics.v1 import metrics_pb2 as pb2
+from opentelemetry.sdk.metrics.export import (
+    MetricsData,
+    Gauge,
+    Histogram as HistogramType,
+    Sum,
+    ExponentialHistogram as ExponentialHistogramType,
+)
+from typing import Dict
+from opentelemetry.proto.resource.v1.resource_pb2 import (
+    Resource as PB2Resource,
+)
+from opentelemetry.sdk.environment_variables import (
+    OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION,
+)
+from opentelemetry.sdk.metrics.view import (
+    ExponentialBucketHistogramAggregation,
+    ExplicitBucketHistogramAggregation,
+)
+
+_logger = logging.getLogger(__name__)
+
+
+class OTLPMetricExporterMixin:
+    def _common_configuration(
+        self,
+        preferred_temporality: Dict[type, AggregationTemporality] = None,
+        preferred_aggregation: Dict[type, Aggregation] = None,
+    ) -> None:
+
+        MetricExporter.__init__(
+            self,
+            preferred_temporality=self._get_temporality(preferred_temporality),
+            preferred_aggregation=self._get_aggregation(preferred_aggregation),
+        )
+
+    def _get_temporality(
+        self, preferred_temporality: Dict[type, AggregationTemporality]
+    ) -> Dict[type, AggregationTemporality]:
+
+        otel_exporter_otlp_metrics_temporality_preference = (
+            environ.get(
+                OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE,
+                "CUMULATIVE",
+            )
+            .upper()
+            .strip()
+        )
+
+        if otel_exporter_otlp_metrics_temporality_preference == "DELTA":
+            instrument_class_temporality = {
+                Counter: AggregationTemporality.DELTA,
+                UpDownCounter: AggregationTemporality.CUMULATIVE,
+                Histogram: AggregationTemporality.DELTA,
+                ObservableCounter: AggregationTemporality.DELTA,
+                ObservableUpDownCounter: AggregationTemporality.CUMULATIVE,
+                ObservableGauge: AggregationTemporality.CUMULATIVE,
+            }
+
+        elif otel_exporter_otlp_metrics_temporality_preference == "LOWMEMORY":
+            instrument_class_temporality = {
+                Counter: AggregationTemporality.DELTA,
+                UpDownCounter: AggregationTemporality.CUMULATIVE,
+                Histogram: AggregationTemporality.DELTA,
+                ObservableCounter: AggregationTemporality.CUMULATIVE,
+                ObservableUpDownCounter: AggregationTemporality.CUMULATIVE,
+                ObservableGauge: AggregationTemporality.CUMULATIVE,
+            }
+
+        else:
+            if otel_exporter_otlp_metrics_temporality_preference != (
+                "CUMULATIVE"
+            ):
+                _logger.warning(
+                    "Unrecognized OTEL_EXPORTER_METRICS_TEMPORALITY_PREFERENCE"
+                    " value found: "
+                    f"{otel_exporter_otlp_metrics_temporality_preference}, "
+                    "using CUMULATIVE"
+                )
+            instrument_class_temporality = {
+                Counter: AggregationTemporality.CUMULATIVE,
+                UpDownCounter: AggregationTemporality.CUMULATIVE,
+                Histogram: AggregationTemporality.CUMULATIVE,
+                ObservableCounter: AggregationTemporality.CUMULATIVE,
+                ObservableUpDownCounter: AggregationTemporality.CUMULATIVE,
+                ObservableGauge: AggregationTemporality.CUMULATIVE,
+            }
+
+        instrument_class_temporality.update(preferred_temporality or {})
+
+        return instrument_class_temporality
+
+    def _get_aggregation(
+        self,
+        preferred_aggregation: Dict[type, Aggregation],
+    ) -> Dict[type, Aggregation]:
+
+        otel_exporter_otlp_metrics_default_histogram_aggregation = environ.get(
+            OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION,
+            "explicit_bucket_histogram",
+        )
+
+        if otel_exporter_otlp_metrics_default_histogram_aggregation == (
+            "base2_exponential_bucket_histogram"
+        ):
+
+            instrument_class_aggregation = {
+                Histogram: ExponentialBucketHistogramAggregation(),
+            }
+
+        else:
+
+            if otel_exporter_otlp_metrics_default_histogram_aggregation != (
+                "explicit_bucket_histogram"
+            ):
+
+                _logger.warning(
+                    (
+                        "Invalid value for %s: %s, using explicit bucket "
+                        "histogram aggregation"
+                    ),
+                    OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION,
+                    otel_exporter_otlp_metrics_default_histogram_aggregation,
+                )
+
+            instrument_class_aggregation = {
+                Histogram: ExplicitBucketHistogramAggregation(),
+            }
+
+        instrument_class_aggregation.update(preferred_aggregation or {})
+
+        return instrument_class_aggregation
+
+
+def encode_metrics(data: MetricsData) -> ExportMetricsServiceRequest:
+    resource_metrics_dict = {}
+
+    for resource_metrics in data.resource_metrics:
+
+        resource = resource_metrics.resource
+
+        # It is safe to assume that each entry in data.resource_metrics is
+        # associated with an unique resource.
+        scope_metrics_dict = {}
+
+        resource_metrics_dict[resource] = scope_metrics_dict
+
+        for scope_metrics in resource_metrics.scope_metrics:
+
+            instrumentation_scope = scope_metrics.scope
+
+            # The SDK groups metrics in instrumentation scopes already so
+            # there is no need to check for existing instrumentation scopes
+            # here.
+            pb2_scope_metrics = pb2.ScopeMetrics(
+                scope=InstrumentationScope(
+                    name=instrumentation_scope.name,
+                    version=instrumentation_scope.version,
+                )
+            )
+
+            scope_metrics_dict[instrumentation_scope] = pb2_scope_metrics
+
+            for metric in scope_metrics.metrics:
+                pb2_metric = pb2.Metric(
+                    name=metric.name,
+                    description=metric.description,
+                    unit=metric.unit,
+                )
+
+                if isinstance(metric.data, Gauge):
+                    for data_point in metric.data.data_points:
+                        pt = pb2.NumberDataPoint(
+                            attributes=_encode_attributes(
+                                data_point.attributes
+                            ),
+                            time_unix_nano=data_point.time_unix_nano,
+                        )
+                        if isinstance(data_point.value, int):
+                            pt.as_int = data_point.value
+                        else:
+                            pt.as_double = data_point.value
+                        pb2_metric.gauge.data_points.append(pt)
+
+                elif isinstance(metric.data, HistogramType):
+                    for data_point in metric.data.data_points:
+                        pt = pb2.HistogramDataPoint(
+                            attributes=_encode_attributes(
+                                data_point.attributes
+                            ),
+                            time_unix_nano=data_point.time_unix_nano,
+                            start_time_unix_nano=(
+                                data_point.start_time_unix_nano
+                            ),
+                            count=data_point.count,
+                            sum=data_point.sum,
+                            bucket_counts=data_point.bucket_counts,
+                            explicit_bounds=data_point.explicit_bounds,
+                            max=data_point.max,
+                            min=data_point.min,
+                        )
+                        pb2_metric.histogram.aggregation_temporality = (
+                            metric.data.aggregation_temporality
+                        )
+                        pb2_metric.histogram.data_points.append(pt)
+
+                elif isinstance(metric.data, Sum):
+                    for data_point in metric.data.data_points:
+                        pt = pb2.NumberDataPoint(
+                            attributes=_encode_attributes(
+                                data_point.attributes
+                            ),
+                            start_time_unix_nano=(
+                                data_point.start_time_unix_nano
+                            ),
+                            time_unix_nano=data_point.time_unix_nano,
+                        )
+                        if isinstance(data_point.value, int):
+                            pt.as_int = data_point.value
+                        else:
+                            pt.as_double = data_point.value
+                        # note that because sum is a message type, the
+                        # fields must be set individually rather than
+                        # instantiating a pb2.Sum and setting it once
+                        pb2_metric.sum.aggregation_temporality = (
+                            metric.data.aggregation_temporality
+                        )
+                        pb2_metric.sum.is_monotonic = metric.data.is_monotonic
+                        pb2_metric.sum.data_points.append(pt)
+
+                elif isinstance(metric.data, ExponentialHistogramType):
+                    for data_point in metric.data.data_points:
+
+                        if data_point.positive.bucket_counts:
+                            positive = pb2.ExponentialHistogramDataPoint.Buckets(
+                                offset=data_point.positive.offset,
+                                bucket_counts=data_point.positive.bucket_counts,
+                            )
+                        else:
+                            positive = None
+
+                        if data_point.negative.bucket_counts:
+                            negative = pb2.ExponentialHistogramDataPoint.Buckets(
+                                offset=data_point.negative.offset,
+                                bucket_counts=data_point.negative.bucket_counts,
+                            )
+                        else:
+                            negative = None
+
+                        pt = pb2.ExponentialHistogramDataPoint(
+                            attributes=_encode_attributes(
+                                data_point.attributes
+                            ),
+                            time_unix_nano=data_point.time_unix_nano,
+                            start_time_unix_nano=(
+                                data_point.start_time_unix_nano
+                            ),
+                            count=data_point.count,
+                            sum=data_point.sum,
+                            scale=data_point.scale,
+                            zero_count=data_point.zero_count,
+                            positive=positive,
+                            negative=negative,
+                            flags=data_point.flags,
+                            max=data_point.max,
+                            min=data_point.min,
+                        )
+                        pb2_metric.exponential_histogram.aggregation_temporality = (
+                            metric.data.aggregation_temporality
+                        )
+                        pb2_metric.exponential_histogram.data_points.append(pt)
+
+                else:
+                    _logger.warning(
+                        "unsupported data type %s",
+                        metric.data.__class__.__name__,
+                    )
+                    continue
+
+                pb2_scope_metrics.metrics.append(pb2_metric)
+
+    resource_data = []
+    for (
+        sdk_resource,
+        scope_data,
+    ) in resource_metrics_dict.items():
+        resource_data.append(
+            pb2.ResourceMetrics(
+                resource=PB2Resource(
+                    attributes=_encode_attributes(sdk_resource.attributes)
+                ),
+                scope_metrics=scope_data.values(),
+                schema_url=sdk_resource.schema_url,
+            )
+        )
+    resource_metrics = resource_data
+    return ExportMetricsServiceRequest(resource_metrics=resource_metrics)

--- a/src/snowflake/telemetry/_internal/opentelemetry/exporter/otlp/proto/common/_internal/metrics_encoder/__init__.py
+++ b/src/snowflake/telemetry/_internal/opentelemetry/exporter/otlp/proto/common/_internal/metrics_encoder/__init__.py
@@ -13,30 +13,24 @@
 # limitations under the License.
 import logging
 
-from opentelemetry.sdk.metrics.export import (
-    MetricExporter,
-)
-from opentelemetry.sdk.metrics.view import Aggregation
-from os import environ
-from opentelemetry.sdk.metrics import (
-    Counter,
-    Histogram,
-    ObservableCounter,
-    ObservableGauge,
-    ObservableUpDownCounter,
-    UpDownCounter,
-)
 from snowflake.telemetry._internal.opentelemetry.exporter.otlp.proto.common._internal import (
     _encode_attributes,
 )
-from opentelemetry.sdk.environment_variables import (
-    OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE,
+from snowflake.telemetry._internal.opentelemetry.proto.common.v1.common import InstrumentationScope as MarshalInstrumentationScope
+from snowflake.telemetry._internal.opentelemetry.proto.metrics.v1.metrics import (
+    NumberDataPoint as MarshalNumberDataPoint,
+    HistogramDataPoint as MarshalHistogramDataPoint,
+    ExponentialHistogramDataPoint as MarshalExponentialHistogramDataPoint,
+    ExponentialHistogramDataPoint_Buckets as MarshalBuckets,
+    Metric as MarshalMetric,
+    Gauge as MarshalGauge,
+    Histogram as MarshalHistogram,
+    Sum as MarshalSum,
+    ExponentialHistogram as MarshalExponentialHistogram,
+    ResourceMetrics as MarshalResourceMetrics,
+    MetricsData as MarshalMetricsData,
+    ScopeMetrics as MarshalScopeMetrics,
 )
-from opentelemetry.sdk.metrics.export import (
-    AggregationTemporality,
-)
-from snowflake.telemetry._internal.opentelemetry.proto.common.v1.common import InstrumentationScope
-from snowflake.telemetry._internal.opentelemetry.proto.metrics.v1 import metrics as pb2
 from opentelemetry.sdk.metrics.export import (
     MetricsData,
     Gauge,
@@ -44,130 +38,11 @@ from opentelemetry.sdk.metrics.export import (
     Sum,
     ExponentialHistogram as ExponentialHistogramType,
 )
-from typing import Dict
 from snowflake.telemetry._internal.opentelemetry.proto.resource.v1.resource import (
-    Resource as PB2Resource,
-)
-from opentelemetry.sdk.environment_variables import (
-    OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION,
-)
-from opentelemetry.sdk.metrics.view import (
-    ExponentialBucketHistogramAggregation,
-    ExplicitBucketHistogramAggregation,
+    Resource as MarshalResource,
 )
 
 _logger = logging.getLogger(__name__)
-
-
-class OTLPMetricExporterMixin:
-    def _common_configuration(
-        self,
-        preferred_temporality: Dict[type, AggregationTemporality] = None,
-        preferred_aggregation: Dict[type, Aggregation] = None,
-    ) -> None:
-
-        MetricExporter.__init__(
-            self,
-            preferred_temporality=self._get_temporality(preferred_temporality),
-            preferred_aggregation=self._get_aggregation(preferred_aggregation),
-        )
-
-    def _get_temporality(
-        self, preferred_temporality: Dict[type, AggregationTemporality]
-    ) -> Dict[type, AggregationTemporality]:
-
-        otel_exporter_otlp_metrics_temporality_preference = (
-            environ.get(
-                OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE,
-                "CUMULATIVE",
-            )
-            .upper()
-            .strip()
-        )
-
-        if otel_exporter_otlp_metrics_temporality_preference == "DELTA":
-            instrument_class_temporality = {
-                Counter: AggregationTemporality.DELTA,
-                UpDownCounter: AggregationTemporality.CUMULATIVE,
-                Histogram: AggregationTemporality.DELTA,
-                ObservableCounter: AggregationTemporality.DELTA,
-                ObservableUpDownCounter: AggregationTemporality.CUMULATIVE,
-                ObservableGauge: AggregationTemporality.CUMULATIVE,
-            }
-
-        elif otel_exporter_otlp_metrics_temporality_preference == "LOWMEMORY":
-            instrument_class_temporality = {
-                Counter: AggregationTemporality.DELTA,
-                UpDownCounter: AggregationTemporality.CUMULATIVE,
-                Histogram: AggregationTemporality.DELTA,
-                ObservableCounter: AggregationTemporality.CUMULATIVE,
-                ObservableUpDownCounter: AggregationTemporality.CUMULATIVE,
-                ObservableGauge: AggregationTemporality.CUMULATIVE,
-            }
-
-        else:
-            if otel_exporter_otlp_metrics_temporality_preference != (
-                "CUMULATIVE"
-            ):
-                _logger.warning(
-                    "Unrecognized OTEL_EXPORTER_METRICS_TEMPORALITY_PREFERENCE"
-                    " value found: "
-                    f"{otel_exporter_otlp_metrics_temporality_preference}, "
-                    "using CUMULATIVE"
-                )
-            instrument_class_temporality = {
-                Counter: AggregationTemporality.CUMULATIVE,
-                UpDownCounter: AggregationTemporality.CUMULATIVE,
-                Histogram: AggregationTemporality.CUMULATIVE,
-                ObservableCounter: AggregationTemporality.CUMULATIVE,
-                ObservableUpDownCounter: AggregationTemporality.CUMULATIVE,
-                ObservableGauge: AggregationTemporality.CUMULATIVE,
-            }
-
-        instrument_class_temporality.update(preferred_temporality or {})
-
-        return instrument_class_temporality
-
-    def _get_aggregation(
-        self,
-        preferred_aggregation: Dict[type, Aggregation],
-    ) -> Dict[type, Aggregation]:
-
-        otel_exporter_otlp_metrics_default_histogram_aggregation = environ.get(
-            OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION,
-            "explicit_bucket_histogram",
-        )
-
-        if otel_exporter_otlp_metrics_default_histogram_aggregation == (
-            "base2_exponential_bucket_histogram"
-        ):
-
-            instrument_class_aggregation = {
-                Histogram: ExponentialBucketHistogramAggregation(),
-            }
-
-        else:
-
-            if otel_exporter_otlp_metrics_default_histogram_aggregation != (
-                "explicit_bucket_histogram"
-            ):
-
-                _logger.warning(
-                    (
-                        "Invalid value for %s: %s, using explicit bucket "
-                        "histogram aggregation"
-                    ),
-                    OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION,
-                    otel_exporter_otlp_metrics_default_histogram_aggregation,
-                )
-
-            instrument_class_aggregation = {
-                Histogram: ExplicitBucketHistogramAggregation(),
-            }
-
-        instrument_class_aggregation.update(preferred_aggregation or {})
-
-        return instrument_class_aggregation
 
 
 def encode_metrics(data: MetricsData) -> bytes:
@@ -201,7 +76,7 @@ def encode_metrics(data: MetricsData) -> bytes:
                         else:
                             as_double = data_point.value
 
-                        pt = pb2.NumberDataPoint(
+                        pt = MarshalNumberDataPoint(
                             attributes=_encode_attributes(
                                 data_point.attributes
                             ),
@@ -211,13 +86,13 @@ def encode_metrics(data: MetricsData) -> bytes:
                         )
                         pb2_data_points.append(pt)
                     
-                    pb2_metric_gauge = pb2.Gauge(data_points=pb2_data_points)
+                    pb2_metric_gauge = MarshalGauge(data_points=pb2_data_points)
 
                 elif isinstance(metric.data, HistogramType):
                     pb2_data_points = []
                     pb2_aggregation_temporality = None
                     for data_point in metric.data.data_points:
-                        pt = pb2.HistogramDataPoint(
+                        pt = MarshalHistogramDataPoint(
                             attributes=_encode_attributes(
                                 data_point.attributes
                             ),
@@ -236,7 +111,7 @@ def encode_metrics(data: MetricsData) -> bytes:
                             metric.data.aggregation_temporality
                         )
                         pb2_data_points.append(pt)
-                    pb2_metric_histogram = pb2.Histogram(
+                    pb2_metric_histogram = MarshalHistogram(
                         data_points=pb2_data_points, 
                         aggregation_temporality=pb2_aggregation_temporality
                     )
@@ -252,7 +127,7 @@ def encode_metrics(data: MetricsData) -> bytes:
                             as_int = data_point.value
                         else:
                             as_double = data_point.value
-                        pt = pb2.NumberDataPoint(
+                        pt = MarshalNumberDataPoint(
                             attributes=_encode_attributes(
                                 data_point.attributes
                             ),
@@ -265,13 +140,13 @@ def encode_metrics(data: MetricsData) -> bytes:
                         )
                         # note that because sum is a message type, the
                         # fields must be set individually rather than
-                        # instantiating a pb2.Sum and setting it once
+                        # instantiating a MarshalSum and setting it once
                         pb2_aggregation_temporality = (
                             metric.data.aggregation_temporality
                         )
                         pb2_is_monotonic = metric.data.is_monotonic
                         pb2_data_points.append(pt)
-                    pb2_metric_sum = pb2.Sum(
+                    pb2_metric_sum = MarshalSum(
                         data_points=pb2_data_points,
                         aggregation_temporality=pb2_aggregation_temporality,
                         is_monotonic=pb2_is_monotonic,
@@ -283,7 +158,7 @@ def encode_metrics(data: MetricsData) -> bytes:
                     for data_point in metric.data.data_points:
 
                         if data_point.positive.bucket_counts:
-                            positive = pb2.ExponentialHistogramDataPoint_Buckets(
+                            positive = MarshalBuckets(
                                 offset=data_point.positive.offset,
                                 bucket_counts=data_point.positive.bucket_counts,
                             )
@@ -291,14 +166,14 @@ def encode_metrics(data: MetricsData) -> bytes:
                             positive = None
 
                         if data_point.negative.bucket_counts:
-                            negative = pb2.ExponentialHistogramDataPoint_Buckets(
+                            negative = MarshalBuckets(
                                 offset=data_point.negative.offset,
                                 bucket_counts=data_point.negative.bucket_counts,
                             )
                         else:
                             negative = None
 
-                        pt = pb2.ExponentialHistogramDataPoint(
+                        pt = MarshalExponentialHistogramDataPoint(
                             attributes=_encode_attributes(
                                 data_point.attributes
                             ),
@@ -321,7 +196,7 @@ def encode_metrics(data: MetricsData) -> bytes:
                         )
                         pb2_data_points.append(pt)
                     
-                    pb2_metric_exponential_histogram = pb2.ExponentialHistogram(
+                    pb2_metric_exponential_histogram = MarshalExponentialHistogram(
                         data_points=pb2_data_points,
                         aggregation_temporality=pb2_aggregation_temporality,
                     )
@@ -334,7 +209,7 @@ def encode_metrics(data: MetricsData) -> bytes:
                     continue
 
 
-                pb2_metric = pb2.Metric(
+                pb2_metric = MarshalMetric(
                     name=metric.name,
                     description=metric.description,
                     unit=metric.unit,
@@ -352,8 +227,8 @@ def encode_metrics(data: MetricsData) -> bytes:
             # The SDK groups metrics in instrumentation scopes already so
             # there is no need to check for existing instrumentation scopes
             # here.
-            pb2_scope_metrics = pb2.ScopeMetrics(
-                scope=InstrumentationScope(
+            pb2_scope_metrics = MarshalScopeMetrics(
+                scope=MarshalInstrumentationScope(
                     name=instrumentation_scope.name,
                     version=instrumentation_scope.version,
                 ),
@@ -368,8 +243,8 @@ def encode_metrics(data: MetricsData) -> bytes:
         scope_data,
     ) in resource_metrics_dict.items():
         resource_data.append(
-            pb2.ResourceMetrics(
-                resource=PB2Resource(
+            MarshalResourceMetrics(
+                resource=MarshalResource(
                     attributes=_encode_attributes(sdk_resource.attributes)
                 ),
                 scope_metrics=scope_data.values(),
@@ -377,4 +252,4 @@ def encode_metrics(data: MetricsData) -> bytes:
             )
         )
     resource_metrics = resource_data
-    return bytes(pb2.MetricsData(resource_metrics=resource_metrics))
+    return bytes(MarshalMetricsData(resource_metrics=resource_metrics))

--- a/src/snowflake/telemetry/_internal/opentelemetry/exporter/otlp/proto/common/_internal/trace_encoder/__init__.py
+++ b/src/snowflake/telemetry/_internal/opentelemetry/exporter/otlp/proto/common/_internal/trace_encoder/__init__.py
@@ -1,0 +1,189 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from collections import defaultdict
+from typing import List, Optional, Sequence
+
+from opentelemetry.exporter.otlp.proto.common._internal import (
+    _encode_attributes,
+    _encode_instrumentation_scope,
+    _encode_resource,
+    _encode_span_id,
+    _encode_trace_id,
+)
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
+    ExportTraceServiceRequest as PB2ExportTraceServiceRequest,
+)
+from opentelemetry.proto.trace.v1.trace_pb2 import (
+    ResourceSpans as PB2ResourceSpans,
+)
+from opentelemetry.proto.trace.v1.trace_pb2 import ScopeSpans as PB2ScopeSpans
+from opentelemetry.proto.trace.v1.trace_pb2 import Span as PB2SPan
+from opentelemetry.proto.trace.v1.trace_pb2 import SpanFlags as PB2SpanFlags
+from opentelemetry.proto.trace.v1.trace_pb2 import Status as PB2Status
+from opentelemetry.sdk.trace import Event, ReadableSpan
+from opentelemetry.trace import Link, SpanKind
+from opentelemetry.trace.span import SpanContext, Status, TraceState
+
+# pylint: disable=E1101
+_SPAN_KIND_MAP = {
+    SpanKind.INTERNAL: PB2SPan.SpanKind.SPAN_KIND_INTERNAL,
+    SpanKind.SERVER: PB2SPan.SpanKind.SPAN_KIND_SERVER,
+    SpanKind.CLIENT: PB2SPan.SpanKind.SPAN_KIND_CLIENT,
+    SpanKind.PRODUCER: PB2SPan.SpanKind.SPAN_KIND_PRODUCER,
+    SpanKind.CONSUMER: PB2SPan.SpanKind.SPAN_KIND_CONSUMER,
+}
+
+_logger = logging.getLogger(__name__)
+
+
+def encode_spans(
+    sdk_spans: Sequence[ReadableSpan],
+) -> PB2ExportTraceServiceRequest:
+    return PB2ExportTraceServiceRequest(
+        resource_spans=_encode_resource_spans(sdk_spans)
+    )
+
+
+def _encode_resource_spans(
+    sdk_spans: Sequence[ReadableSpan],
+) -> List[PB2ResourceSpans]:
+    # We need to inspect the spans and group + structure them as:
+    #
+    #   Resource
+    #     Instrumentation Library
+    #       Spans
+    #
+    # First loop organizes the SDK spans in this structure. Protobuf messages
+    # are not hashable so we stick with SDK data in this phase.
+    #
+    # Second loop encodes the data into Protobuf format.
+    #
+    sdk_resource_spans = defaultdict(lambda: defaultdict(list))
+
+    for sdk_span in sdk_spans:
+        sdk_resource = sdk_span.resource
+        sdk_instrumentation = sdk_span.instrumentation_scope or None
+        pb2_span = _encode_span(sdk_span)
+
+        sdk_resource_spans[sdk_resource][sdk_instrumentation].append(pb2_span)
+
+    pb2_resource_spans = []
+
+    for sdk_resource, sdk_instrumentations in sdk_resource_spans.items():
+        scope_spans = []
+        for sdk_instrumentation, pb2_spans in sdk_instrumentations.items():
+            scope_spans.append(
+                PB2ScopeSpans(
+                    scope=(_encode_instrumentation_scope(sdk_instrumentation)),
+                    spans=pb2_spans,
+                )
+            )
+        pb2_resource_spans.append(
+            PB2ResourceSpans(
+                resource=_encode_resource(sdk_resource),
+                scope_spans=scope_spans,
+                schema_url=sdk_resource.schema_url,
+            )
+        )
+
+    return pb2_resource_spans
+
+
+def _span_flags(parent_span_context: Optional[SpanContext]) -> int:
+    flags = PB2SpanFlags.SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK
+    if parent_span_context and parent_span_context.is_remote:
+        flags |= PB2SpanFlags.SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK
+    return flags
+
+
+def _encode_span(sdk_span: ReadableSpan) -> PB2SPan:
+    span_context = sdk_span.get_span_context()
+    return PB2SPan(
+        trace_id=_encode_trace_id(span_context.trace_id),
+        span_id=_encode_span_id(span_context.span_id),
+        trace_state=_encode_trace_state(span_context.trace_state),
+        parent_span_id=_encode_parent_id(sdk_span.parent),
+        name=sdk_span.name,
+        kind=_SPAN_KIND_MAP[sdk_span.kind],
+        start_time_unix_nano=sdk_span.start_time,
+        end_time_unix_nano=sdk_span.end_time,
+        attributes=_encode_attributes(sdk_span.attributes),
+        events=_encode_events(sdk_span.events),
+        links=_encode_links(sdk_span.links),
+        status=_encode_status(sdk_span.status),
+        dropped_attributes_count=sdk_span.dropped_attributes,
+        dropped_events_count=sdk_span.dropped_events,
+        dropped_links_count=sdk_span.dropped_links,
+        flags=_span_flags(sdk_span.parent),
+    )
+
+
+def _encode_events(
+    events: Sequence[Event],
+) -> Optional[List[PB2SPan.Event]]:
+    pb2_events = None
+    if events:
+        pb2_events = []
+        for event in events:
+            encoded_event = PB2SPan.Event(
+                name=event.name,
+                time_unix_nano=event.timestamp,
+                attributes=_encode_attributes(event.attributes),
+                dropped_attributes_count=event.dropped_attributes,
+            )
+            pb2_events.append(encoded_event)
+    return pb2_events
+
+
+def _encode_links(links: Sequence[Link]) -> Sequence[PB2SPan.Link]:
+    pb2_links = None
+    if links:
+        pb2_links = []
+        for link in links:
+            encoded_link = PB2SPan.Link(
+                trace_id=_encode_trace_id(link.context.trace_id),
+                span_id=_encode_span_id(link.context.span_id),
+                attributes=_encode_attributes(link.attributes),
+                dropped_attributes_count=link.attributes.dropped,
+                flags=_span_flags(link.context),
+            )
+            pb2_links.append(encoded_link)
+    return pb2_links
+
+
+def _encode_status(status: Status) -> Optional[PB2Status]:
+    pb2_status = None
+    if status is not None:
+        pb2_status = PB2Status(
+            code=status.status_code.value,
+            message=status.description,
+        )
+    return pb2_status
+
+
+def _encode_trace_state(trace_state: TraceState) -> Optional[str]:
+    pb2_trace_state = None
+    if trace_state is not None:
+        pb2_trace_state = ",".join(
+            [f"{key}={value}" for key, value in (trace_state.items())]
+        )
+    return pb2_trace_state
+
+
+def _encode_parent_id(context: Optional[SpanContext]) -> Optional[bytes]:
+    if context:
+        return _encode_span_id(context.span_id)
+    return None

--- a/src/snowflake/telemetry/_internal/opentelemetry/exporter/otlp/proto/common/_log_encoder.py
+++ b/src/snowflake/telemetry/_internal/opentelemetry/exporter/otlp/proto/common/_log_encoder.py
@@ -1,0 +1,20 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from opentelemetry.exporter.otlp.proto.common._internal._log_encoder import (
+    encode_logs,
+)
+
+__all__ = ["encode_logs"]

--- a/src/snowflake/telemetry/_internal/opentelemetry/exporter/otlp/proto/common/_log_encoder.py
+++ b/src/snowflake/telemetry/_internal/opentelemetry/exporter/otlp/proto/common/_log_encoder.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from opentelemetry.exporter.otlp.proto.common._internal._log_encoder import (
+from snowflake.telemetry._internal.opentelemetry.exporter.otlp.proto.common._internal._log_encoder import (
     encode_logs,
 )
 

--- a/src/snowflake/telemetry/_internal/opentelemetry/exporter/otlp/proto/common/metrics_encoder.py
+++ b/src/snowflake/telemetry/_internal/opentelemetry/exporter/otlp/proto/common/metrics_encoder.py
@@ -1,0 +1,20 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from opentelemetry.exporter.otlp.proto.common._internal.metrics_encoder import (
+    encode_metrics,
+)
+
+__all__ = ["encode_metrics"]

--- a/src/snowflake/telemetry/_internal/opentelemetry/exporter/otlp/proto/common/metrics_encoder.py
+++ b/src/snowflake/telemetry/_internal/opentelemetry/exporter/otlp/proto/common/metrics_encoder.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from opentelemetry.exporter.otlp.proto.common._internal.metrics_encoder import (
+from snowflake.telemetry._internal.opentelemetry.exporter.otlp.proto.common._internal.metrics_encoder import (
     encode_metrics,
 )
 

--- a/src/snowflake/telemetry/_internal/opentelemetry/exporter/otlp/proto/common/trace_encoder.py
+++ b/src/snowflake/telemetry/_internal/opentelemetry/exporter/otlp/proto/common/trace_encoder.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from opentelemetry.exporter.otlp.proto.common._internal.trace_encoder import (
+from snowflake.telemetry._internal.opentelemetry.exporter.otlp.proto.common._internal.trace_encoder import (
     encode_spans,
 )
 

--- a/src/snowflake/telemetry/_internal/opentelemetry/exporter/otlp/proto/common/trace_encoder.py
+++ b/src/snowflake/telemetry/_internal/opentelemetry/exporter/otlp/proto/common/trace_encoder.py
@@ -1,0 +1,20 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from opentelemetry.exporter.otlp.proto.common._internal.trace_encoder import (
+    encode_spans,
+)
+
+__all__ = ["encode_spans"]

--- a/src/snowflake/telemetry/_internal/opentelemetry/exporter/otlp/proto/common/version.py
+++ b/src/snowflake/telemetry/_internal/opentelemetry/exporter/otlp/proto/common/version.py
@@ -1,0 +1,15 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__version__ = "1.26.0"

--- a/tests/snowflake-telemetry-test-utils/setup.py
+++ b/tests/snowflake-telemetry-test-utils/setup.py
@@ -17,12 +17,16 @@ setup(
     install_requires=[
         "pytest >= 7.0.0",
         "snowflake-telemetry-python == 0.6.0.dev",
+        # Dependencies for test_proto_serialization
         "opentelemetry-exporter-otlp-proto-common == 1.26.0",
         "hypothesis >= 6.0.0",
+        # Dependencies for test_protoc_plugin
         "Jinja2",
         "grpcio-tools",
         "black",
         "isort",
+        # Dependencies for benchmarks
+        "google-benchmark",
     ],
     packages=find_namespace_packages(
         where='src'

--- a/tests/snowflake-telemetry-test-utils/setup.py
+++ b/tests/snowflake-telemetry-test-utils/setup.py
@@ -17,11 +17,12 @@ setup(
     install_requires=[
         "pytest >= 7.0.0",
         "snowflake-telemetry-python == 0.6.0.dev",
-        "Jinja2",
-        "grpcio-tools", 
-        "black", 
-        "isort",
+        "opentelemetry-exporter-otlp-proto-common == 1.26.0",
         "hypothesis >= 6.0.0",
+        "Jinja2",
+        "grpcio-tools",
+        "black",
+        "isort",
     ],
     packages=find_namespace_packages(
         where='src'

--- a/tests/test_log_encoder.py
+++ b/tests/test_log_encoder.py
@@ -22,7 +22,7 @@ from opentelemetry.exporter.otlp.proto.common._internal import (
     _encode_trace_id,
     _encode_value,
 )
-from opentelemetry.exporter.otlp.proto.common._log_encoder import encode_logs
+from snowflake.telemetry._internal.opentelemetry.exporter.otlp.proto.common._log_encoder import encode_logs
 from opentelemetry.proto.collector.logs.v1.logs_service_pb2 import (
     ExportLogsServiceRequest,
 )
@@ -55,7 +55,7 @@ from snowflake.telemetry.test.logs_test_utils import (
 class TestOTLPLogEncoder(unittest.TestCase):
     def test_encode(self):
         sdk_logs, expected_encoding = self.get_test_logs()
-        self.assertEqual(encode_logs(sdk_logs), expected_encoding)
+        self.assertEqual(encode_logs(sdk_logs), expected_encoding.SerializeToString())
 
     def test_proto_log_exporter(self):
         sdk_logs, expected_encoding = self.get_test_logs()
@@ -69,11 +69,13 @@ class TestOTLPLogEncoder(unittest.TestCase):
 
     def test_dropped_attributes_count(self):
         sdk_logs = self._get_test_logs_dropped_attributes()
-        encoded_logs = encode_logs(sdk_logs)
+        encoded_logs = bytes(encode_logs(sdk_logs))
+        decoded_logs = PB2LogsData()
+        decoded_logs.ParseFromString(encoded_logs)
         self.assertTrue(hasattr(sdk_logs[0].log_record, "dropped_attributes"))
         self.assertEqual(
             # pylint:disable=no-member
-            encoded_logs.resource_logs[0]
+            decoded_logs.resource_logs[0]
             .scope_logs[0]
             .log_records[0]
             .dropped_attributes_count,

--- a/tests/test_metrics_encoder.py
+++ b/tests/test_metrics_encoder.py
@@ -15,7 +15,7 @@
 # pylint: disable=protected-access
 import unittest
 
-from opentelemetry.exporter.otlp.proto.common.metrics_encoder import (
+from snowflake.telemetry._internal.opentelemetry.exporter.otlp.proto.common.metrics_encoder import (
     encode_metrics,
 )
 from opentelemetry.proto.collector.metrics.v1.metrics_service_pb2 import (
@@ -160,7 +160,7 @@ class TestOTLPMetricsEncoder(unittest.TestCase):
             ]
         )
         actual = encode_metrics(metrics_data)
-        self.assertEqual(expected, actual)
+        self.assertEqual(expected.SerializeToString(), actual)
         self.metric_writer.clear()
         self.exporter.export(metrics_data)
         protos = self.metric_writer.get_finished_protos()
@@ -246,7 +246,7 @@ class TestOTLPMetricsEncoder(unittest.TestCase):
             ]
         )
         actual = encode_metrics(metrics_data)
-        self.assertEqual(expected, actual)
+        self.assertEqual(expected.SerializeToString(), actual)
         self.metric_writer.clear()
         self.exporter.export(metrics_data)
         protos = self.metric_writer.get_finished_protos()
@@ -329,7 +329,7 @@ class TestOTLPMetricsEncoder(unittest.TestCase):
             ]
         )
         actual = encode_metrics(metrics_data)
-        self.assertEqual(expected, actual)
+        self.assertEqual(expected.SerializeToString(), actual)
         self.metric_writer.clear()
         self.exporter.export(metrics_data)
         protos = self.metric_writer.get_finished_protos()
@@ -412,7 +412,7 @@ class TestOTLPMetricsEncoder(unittest.TestCase):
             ]
         )
         actual = encode_metrics(metrics_data)
-        self.assertEqual(expected, actual)
+        self.assertEqual(expected.SerializeToString(), actual)
         self.metric_writer.clear()
         self.exporter.export(metrics_data)
         protos = self.metric_writer.get_finished_protos()
@@ -503,7 +503,7 @@ class TestOTLPMetricsEncoder(unittest.TestCase):
             ]
         )
         actual = encode_metrics(metrics_data)
-        self.assertEqual(expected, actual)
+        self.assertEqual(expected.SerializeToString(), actual)
         self.metric_writer.clear()
         self.exporter.export(metrics_data)
         protos = self.metric_writer.get_finished_protos()
@@ -731,7 +731,7 @@ class TestOTLPMetricsEncoder(unittest.TestCase):
             ]
         )
         actual = encode_metrics(metrics_data)
-        self.assertEqual(expected, actual)
+        self.assertEqual(expected.SerializeToString(), actual)
         self.metric_writer.clear()
         self.exporter.export(metrics_data)
         protos = self.metric_writer.get_finished_protos()
@@ -857,7 +857,7 @@ class TestOTLPMetricsEncoder(unittest.TestCase):
         )
         # pylint: disable=protected-access
         actual = encode_metrics(metrics_data)
-        self.assertEqual(expected, actual)
+        self.assertEqual(expected.SerializeToString(), actual)
         self.metric_writer.clear()
         self.exporter.export(metrics_data)
         protos = self.metric_writer.get_finished_protos()

--- a/tests/test_trace_encoder.py
+++ b/tests/test_trace_encoder.py
@@ -25,7 +25,7 @@ from opentelemetry.exporter.otlp.proto.common._internal.trace_encoder import (
     _SPAN_KIND_MAP,
     _encode_status,
 )
-from opentelemetry.exporter.otlp.proto.common.trace_encoder import encode_spans
+from snowflake.telemetry._internal.opentelemetry.exporter.otlp.proto.common.trace_encoder import encode_spans
 from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
     ExportTraceServiceRequest as PB2ExportTraceServiceRequest,
 )
@@ -67,7 +67,7 @@ from snowflake.telemetry.test.traces_test_utils import (
 class TestOTLPTraceEncoder(unittest.TestCase):
     def test_encode_spans(self):
         otel_spans, expected_encoding = self.get_exhaustive_test_spans()
-        self.assertEqual(encode_spans(otel_spans), expected_encoding)
+        self.assertEqual(encode_spans(otel_spans), expected_encoding.SerializeToString())
 
     def test_proto_span_exporter(self):
         otel_spans, expected_encoding = self.get_exhaustive_test_spans()


### PR DESCRIPTION
This PR
- Internalizes some encoding logic from opentelemetry-exporter-otlp-proto-common under the directory `src/snowflake/internal/opentelemetry/exporter/**`
- Modifies the above logic to use the custom serialization structures introduced in https://github.com/snowflakedb/snowflake-telemetry-python/pull/39
- Updates tests to check for equality of serialized bytes rather than PB2 objects, since the new code only produces bytes
- Adds a micro-benchmark to compare encoding performance of the original library and the new approach under the `benchmarks/**` directory

Todo in future PRs:
- [ ] Add import time and memory benchmarks
- [ ] Add branching / try..except import to use the original opentelemetry-exporter-otlp-proto-common if it is present in the runtime instead of the custom logic
- [ ] Add a step to the release script & Jenkins job to test the .conda / .tar.bz2 package in a conda environment end to end 
- [ ] Release v0.6.0


```
------------------------------------------------------------------------------
Benchmark                                    Time             CPU   Iterations
------------------------------------------------------------------------------
test_bm_serialize_logs_data_4MB      218404625 ns    218404667 ns            3
test_bm_pb2_serialize_logs_data_4MB  279917764 ns    279916000 ns            3
test_bm_serialize_logs_data              35747 ns        35747 ns        19741
test_bm_pb2_serialize_logs_data          41652 ns        41651 ns        16939
test_bm_serialize_metrics_data           59798 ns        59798 ns        11593
test_bm_pb2_serialize_metrics_data       70521 ns        70521 ns         9815
test_bm_serialize_traces_data            47156 ns        47156 ns        14807
test_bm_pb2_serialize_traces_data        59690 ns        59690 ns        11766
```


https://docs.google.com/document/d/1plfwWBVRJGzU5dl3kph4HWwgnxBc8TJm0JCyanCdJuM/edit?usp=sharing