### PR TITLE
Set severity_text to `UNSPECIFIED` when unavailable

### DIFF
--- a/src/snowflake/telemetry/logs/__init__.py
+++ b/src/snowflake/telemetry/logs/__init__.py
@@ -66,7 +66,7 @@ class SnowflakeLogFormatter(logging.Formatter):
         """
         level = py_level_name.upper()
         if level not in _PY_LOG_LEVELS:
-            return "TRACE"
+            return "UNSPECIFIED"
         if level == "WARNING":
             return "WARN"
         if level == "CRITICAL":

--- a/tests/test_snowflake_log_formatter.py
+++ b/tests/test_snowflake_log_formatter.py
@@ -60,5 +60,5 @@ class TestSnowflakeLogFormatter(unittest.TestCase):
         self.assertEqual("WARN", SnowflakeLogFormatter.get_severity_text("warning"))
         self.assertEqual("DEBUG", SnowflakeLogFormatter.get_severity_text("debug"))
         self.assertEqual("ERROR", SnowflakeLogFormatter.get_severity_text("error"))
-        self.assertEqual("TRACE", SnowflakeLogFormatter.get_severity_text("notset"))
-        self.assertEqual("TRACE", SnowflakeLogFormatter.get_severity_text("random"))
+        self.assertEqual("UNSPECIFIED", SnowflakeLogFormatter.get_severity_text("notset"))
+        self.assertEqual("UNSPECIFIED", SnowflakeLogFormatter.get_severity_text("random"))


### PR DESCRIPTION
Python doesn't have a `TRACE` level and setting to this will confuse users. So defaulting to `UNSPECIFIED` when we can't parse the severity text.